### PR TITLE
Add SecureField support

### DIFF
--- a/Sources/MbSwiftUIFirstResponder/Mac/Interface - mac.swift
+++ b/Sources/MbSwiftUIFirstResponder/Mac/Interface - mac.swift
@@ -14,6 +14,13 @@ extension TextField {
     }
 }
 
+extension SecureField {
+    public func firstResponder<V: Hashable>(id: V, firstResponder: Binding<V?>, resignableUserOperations: MbFirstResponder.TextField.ResignableUserOperations = .all, didBackViewLoaded: ((NSTextField) -> Void)? = nil) -> some View {
+        self
+            .background(MbFRHackView<V, NSTextField>(id: id, firstResponder: firstResponder, resignableUserOperations: resignableUserOperations, didBackViewLoaded: didBackViewLoaded))
+    }
+}
+
 extension TextEditor {
     public func firstResponder<V: Hashable>(id: V, firstResponder: Binding<V?>, resignableUserOperations: MbFirstResponder.TextEditor.ResignableUserOperations = .all, didBackViewLoaded: ((NSTextView) -> Void)? = nil) -> some View {
         self

--- a/Sources/MbSwiftUIFirstResponder/iOS/Interface.swift
+++ b/Sources/MbSwiftUIFirstResponder/iOS/Interface.swift
@@ -14,6 +14,13 @@ extension TextField {
     }
 }
 
+extension SecureField {
+    public func firstResponder<V: Hashable>(id: V, firstResponder: Binding<V?>, resignableUserOperations: MbFirstResponder.TextField.ResignableUserOperations = .all) -> some View {
+        self
+            .background(MbFRHackView<V, UITextField>(id: id, firstResponder: firstResponder, resignableUserOperations: resignableUserOperations))
+    }
+}
+
 extension TextEditor {
     public func firstResponder<V: Hashable>(id: V, firstResponder: Binding<V?>, resignableUserOperations: MbFirstResponder.TextEditor.ResignableUserOperations = .all) -> some View {
         self


### PR DESCRIPTION
This PR adds support for SecureField on macOS and iOS. As it turns out, simply adding extension just works, because SecureField is backed by UITextField on iOS and NSTextField on macOS.

Closes #7.